### PR TITLE
Debugging recent failures

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,9 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-matrix
         run: |
-          echo "matrix={\"node\":[$(python getter.py)]}" >> $GITHUB_OUTPUT
+          set -e
+          NODES=$(python getter.py)
+          echo "matrix={\"node\":[${NODES}]}" >> "$GITHUB_OUTPUT"
 
   run_notebook:
     needs:
@@ -63,10 +65,16 @@ jobs:
             ])'
       - run: mkdir -pv notebooks
       - run: python3 tester.py ${{ matrix.node }}
+      - name: Sanitize artifact name
+        id: sanitize
+        run: |
+          SAFE_NAME="${{ matrix.node }}"
+          SAFE_NAME="${SAFE_NAME//\//_}"
+          echo "safe_name=$SAFE_NAME" >> "$GITHUB_OUTPUT"
       - name: Upload new notebook
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.node }}
+          name: ${{ steps.sanitize.outputs.safe_name }}
           path: notebooks/*.ipynb
           retention-days: 7
       - name: Notify Slack Action

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,8 +20,7 @@ jobs:
       - id: set-matrix
         run: |
           set -e
-          NODES=$(python getter.py)
-          echo "matrix={\"node\":[${NODES}]}" >> "$GITHUB_OUTPUT"
+          echo "matrix={\"node\":[$(python getter.py)]}" >> $GITHUB_OUTPUT
 
   run_notebook:
     needs:


### PR DESCRIPTION
Fix PR "fixes" the failures found in https://github.com/oscar-system/TutorialTesterforOscar/actions/runs/19690595519.

What happened?
Yesterday, I added new tutorials (to the examples.yml) but forgot to specify the entry "branch". This cause our python script getter.py to fail in the above workflow. Sadly, the actual python error was not caught (we assume in this script that the field branch is always populated, but it was not for some entries in the .yml), instead an "empty matrix" cause the workflow to fail. But in a way that our slack notification was not triggered.

What this PR does
It reveals the actual python error should getter.py fail. In this case, the workflow will fail. (Hopefully, in such a way that our slack notification is triggered.)