### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
While looking into https://github.com/oscar-system/TutorialTesterforOscar/pull/12, I noticed quite a bunch of warnings in the CI logs, namely:
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684, actions/checkout@v4, actions/upload-artifact@v4, julia-actions/setup-julia@v2, ravsamhq/notify-slack-action@2.5.0. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

(e.g. in https://github.com/oscar-system/TutorialTesterforOscar/actions/runs/24545491188)

Adding dependabot will help resolving these (and similarly for any future updates). The concrete config options are copied from https://github.com/oscar-system/Oscar.jl/blob/cee2e4dd1f83b35e9b7fb233b48ebe99f33934fa/.github/dependabot.yml.